### PR TITLE
Fix Unicode in custom titles

### DIFF
--- a/source/builder.cpp
+++ b/source/builder.cpp
@@ -187,17 +187,13 @@ std::string Builder::buildSRL(std::string filename, bool randomTid, std::string 
         }
     }
     if (!customTitle.empty()) {
-        char cTitle[0x100/2] = {0};
-        strncpy(cTitle,customTitle.c_str(),0x100/2);
+        uint16_t cTitle[0x80] = {0};
+        utf8_to_utf16(cTitle, (u8*)customTitle.c_str(), 0x80);
         for(int i=0;i<6;i++) {
-            for (int x=0;x<0x100/2;x++) {
-                banner.titles[i][x] = cTitle[x];
-            }
+            memcpy(banner.titles[i], cTitle, 0x80 * sizeof(uint16_t));
         }
         for(int i=0;i<2;i++) {
-            for (int x=0;x<0x100/2;x++) {
-                extraTitles[i][x] = cTitle[x];
-            }
+            memcpy(extraTitles[i], cTitle, 0x80 * sizeof(uint16_t));
         }
     }
     // Set header


### PR DESCRIPTION
Simply changes it to do a proper UTF-8 to UTF-16 conversion instead of just spacing out all the bytes so that non-ASCII text doesn't come out as a jumbled mess.

Before:
![HNI_0001](https://user-images.githubusercontent.com/41608708/148904198-a0bf5b0c-3d79-4b1a-9a39-90ba85298249.JPG)

After:
![2022-01-11_03-06-22 268_top](https://user-images.githubusercontent.com/41608708/148904417-e76a5f94-ab99-4b19-8b48-6f8db9251aa5.png)




