### PR TITLE
Implement DSiWare check

### DIFF
--- a/romfs/lang/default.json
+++ b/romfs/lang/default.json
@@ -22,6 +22,7 @@
     "builder_ErrInRet":"Error in:%s\n%s\nret: 0x%xl",
     "builder_ErrIn":"Error in:%s\n%s",
     "builder_invalidBannerCRC":"Invalid banner CRC %s",
+    "builder_isDSiWare":"%s is DSiWare, halt.",
 
     "config_foundTemplate":"Found %s on %s",
     "config_searchTemplates":"Checking %s for templates",

--- a/source/builder.cpp
+++ b/source/builder.cpp
@@ -128,6 +128,17 @@ std::string Builder::buildSRL(std::string filename, bool randomTid, std::string 
     }
     std::ifstream f(filename);
     f.seekg(0);
+
+	// DSiWare check
+	tDSiHeader targetDSiWareCheck = {};
+    f.read((char*)&targetDSiWareCheck, sizeof(targetDSiWareCheck));
+    // DSiWare carts are 00
+	if ((targetDSiWareCheck.tid_high & 0xFF) > 0)
+	{
+		logger.error(gLang.parseString("builder_isDSiWare", filename.c_str()));
+        return "";
+	}
+    f.seekg(0);
     f.read((char*)&header,sizeof(header));
     bool extendedHeader = (header.headerSize == 0x4000);
     if (header.bannerOffset == 0) {


### PR DESCRIPTION
Related issue: https://github.com/MechanicalDragon0687/NDSForwarder/issues/18

It will outright fail. Don't really know how to properly output an error text, currently all errors are just a random u32 value for some odd reason.

But logger will output builder_isDSiWare.